### PR TITLE
fix: Use random-access-memory for Hypercore storage

### DIFF
--- a/pear-p2p-chat-app/chat.js
+++ b/pear-p2p-chat-app/chat.js
@@ -3,6 +3,7 @@ const Hyperswarm = require('hyperswarm');
 const Hypercore = require('hypercore');
 const crypto = require('crypto');
 const readline = require('readline');
+const ram = require('random-access-memory'); // Added random-access-memory
 
 // --- Hyperswarm Setup ---
 const topicString = 'pear-friend-connect-chat-app-v3'; // New topic for profile version
@@ -12,7 +13,8 @@ console.log(`Chat Topic: ${topic.toString('hex')}`);
 const swarm = new Hyperswarm();
 
 // --- Local Hypercore Setup ---
-const localCore = new Hypercore(null, { valueEncoding: 'utf-8', persist: false });
+// Updated to use ram for storage
+const localCore = new Hypercore(ram, { valueEncoding: 'utf-8', persist: false });
 
 // --- Readline Interface for User Input ---
 const rl = readline.createInterface({
@@ -81,7 +83,8 @@ async function main() {
           console.log(`\n[System] Received Hypercore key and username from ${peerName} (Key: ${remoteHypercoreKey.substring(0, 6)}...)`);
 
           // Initialize Remote Hypercore for reading
-          remoteCore = new Hypercore(null, remoteHypercoreKey, { 
+          // Updated to use ram for storage
+          remoteCore = new Hypercore(ram, remoteHypercoreKey, { 
             valueEncoding: 'utf-8', 
             persist: false,
             sparse: true

--- a/pear-p2p-chat-app/package-lock.json
+++ b/pear-p2p-chat-app/package-lock.json
@@ -11,10 +11,10 @@
       "dependencies": {
         "hypercore": "^11.8.2",
         "hyperdht": "^6.20.5",
-        "hyperswarm": "^4.11.7"
+        "hyperswarm": "^4.11.7",
+        "random-access-memory": "^6.2.1"
       },
       "devDependencies": {
-        "random-access-memory": "^6.2.1",
         "tape": "^5.9.0"
       }
     },
@@ -1768,7 +1768,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/random-access-memory/-/random-access-memory-6.2.1.tgz",
       "integrity": "sha512-hUeu1PbGLmWeyze9LwwSNaqloivNYjFsARIYxRdgUgn0wrdvMG+RszrfTG8814zfcXOgy4pFO2TpX/Cl3hRO4w==",
-      "dev": true,
       "dependencies": {
         "b4a": "^1.6.0",
         "is-options": "^1.0.2",
@@ -1779,7 +1778,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/random-access-storage/-/random-access-storage-3.0.2.tgz",
       "integrity": "sha512-Es9maUyWdJXWKckKy9s1+vT+DEgAt+PBb9lxPaake/0EDUsHehloKGv9v1zimS2V3gpFAcQXubvc1Rgci2sDPQ==",
-      "dev": true,
       "dependencies": {
         "bare-events": "^2.2.0",
         "queue-tick": "^1.0.0"
@@ -2482,9 +2480,9 @@
       }
     },
     "node_modules/which-runtime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.2.1.tgz",
-      "integrity": "sha512-8feIHccQFH/whiA1fD1b4c5+Q7T4ry1g1oHYc2mHnFh81tTQFsCvy3zhS2geUapkFAVBddUT/AM1a3rbqJweFg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.0.tgz",
+      "integrity": "sha512-mQrEBUe15PdEuJvrBlvy3tika6sxQrkblI7JQ9kXeg8Lcby9FwmKvAYrCT3wLh91k6ltost7AVM7qYhjC8N0Zg=="
     },
     "node_modules/which-typed-array": {
       "version": "1.1.19",

--- a/pear-p2p-chat-app/package.json
+++ b/pear-p2p-chat-app/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "hypercore": "^11.8.2",
     "hyperdht": "^6.20.5",
-    "hyperswarm": "^4.11.7"
+    "hyperswarm": "^4.11.7",
+    "random-access-memory": "^6.2.1"
   },
   "devDependencies": {
-    "random-access-memory": "^6.2.1",
     "tape": "^5.9.0"
   }
 }


### PR DESCRIPTION
This commit addresses a TypeError that occurred during Hypercore initialization when using `null` as the storage argument with `persist: false`.

Changes:
- Added `random-access-memory` as a production dependency in `package.json`.
- Updated `chat.js` to import `random-access-memory` and use it when creating Hypercore instances (both local and remote cores). This ensures that Hypercores are explicitly backed by in-memory storage, preventing errors related to missing storage paths.